### PR TITLE
Change feature `static-linking` -> `dynamic-linking`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ cudarc = { git = "https://github.com/coreylowman/cudarc", rev = "d3405fa5ce18068
 
 [features]
 default = []
-static-linking = ["cudarc/static-linking"]
+dynamic-linking = ["cudarc/dynamic-linking"]


### PR DESCRIPTION
## 🗣 Description
No `static-linking` feature in cudarc anymore. 

## 🔨 Related Issues
 - See related change in cudarc: https://github.com/coreylowman/cudarc/pull/211 

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
