### PR TITLE
Port to candle-core 0.10.1 / cudarc 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,27 @@ edition = "2021"
 description = "CUBLASLt gemm for the candle ML framework."
 
 [dependencies]
-candle = { version = "*", package = "candle-core", features = ["cuda"]}
-cudarc = { version = "0.17.6", default-features = false, features = [ "cublaslt", "f16" ]}
+# Depend on candle-core by its canonical name (renamed to `candle` in code)
+# so the workspace's [patch.crates-io] override for `candle-core` applies.
+# Previously this dep was declared as `candle = { version = "*", package = "candle-core" }`
+# which silently resolved to a different `candle-core` version than the rest of
+# the dep graph (0.8.4 vs 0.10.1), causing `CudaSlice` / `CudaView` to be
+# distinct types between this crate and candle, which broke the `DevicePtr`
+# trait bounds in `cudarc::cublaslt::Matmul::matmul`.
+candle = { version = "=0.10.1", package = "candle-core", features = ["cuda"] }
+cudarc = { version = "0.19", default-features = false, features = [
+    "std",
+    "cublas",
+    "cublaslt",
+    "curand",
+    "driver",
+    "nvrtc",
+    "f16",
+    "f8",
+    "cuda-version-from-build-system",
+    "dynamic-linking",
+] }
 half = { version = "2.3.1", features = ["num-traits"] }
-
-[patch.crates-io]
-cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "34834440ada40a7c53d46d45b65d5e42c5f5d903", default-features = false, features = [ "cublaslt", "f16" ]}
 
 [features]
 default = []
-dynamic-linking = ["cudarc/dynamic-linking"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ pub use cudarc::cublaslt::Activation;
 use std::ffi::c_int;
 
 use candle::backend::BackendStorage;
-use candle::cuda_backend::WrapErr;
 use candle::{CpuStorage, Device, Layout, Result, Shape, Storage, Tensor};
 use half::{bf16, f16};
 use std::sync::Arc;
@@ -19,7 +18,7 @@ impl CublasLt {
             _ => candle::bail!("`device` must be a `cuda` device"),
         };
 
-        let inner = CudaBlasLT::new(dev.cuda_device()).unwrap();
+        let inner = CudaBlasLT::new(dev.cuda_stream()).unwrap();
 
         Ok(Self(Arc::new(inner)))
     }
@@ -97,11 +96,12 @@ impl CublasLTMatmul {
             c.clone()
         } else {
             // Allocate out tensor
-            unsafe { dev.alloc::<f16>(out_shape.elem_count()).w()? }
+            unsafe { dev.alloc::<f16>(out_shape.elem_count())? }
         };
 
         let config = MatmulConfig {
             transa: true,
+            transc: false,
             transb: false,
             m: m as u64,
             n: n as u64,
@@ -192,11 +192,12 @@ impl CublasLTMatmul {
             c.clone()
         } else {
             // Allocate out tensor
-            unsafe { dev.alloc::<bf16>(out_shape.elem_count()).w()? }
+            unsafe { dev.alloc::<bf16>(out_shape.elem_count())? }
         };
 
         let config = MatmulConfig {
             transa: true,
+            transc: false,
             transb: false,
             m: m as u64,
             n: n as u64,
@@ -287,11 +288,12 @@ impl CublasLTMatmul {
             c.clone()
         } else {
             // Allocate out tensor
-            unsafe { dev.alloc::<f32>(out_shape.elem_count()).w()? }
+            unsafe { dev.alloc::<f32>(out_shape.elem_count())? }
         };
 
         let config = MatmulConfig {
             transa: true,
+            transc: false,
             transb: false,
             m: m as u64,
             n: n as u64,
@@ -504,13 +506,14 @@ impl CublasLTBatchMatmul {
         } else {
             // Allocate out tensor
             (
-                unsafe { dev.alloc::<f16>(out_shape.elem_count()).w()? },
+                unsafe { dev.alloc::<f16>(out_shape.elem_count())? },
                 (n * m),
             )
         };
 
         let config = MatmulConfig {
             transa: true,
+            transc: false,
             transb: false,
             m: m as u64,
             n: n as u64,
@@ -607,13 +610,14 @@ impl CublasLTBatchMatmul {
         } else {
             // Allocate out tensor
             (
-                unsafe { dev.alloc::<bf16>(out_shape.elem_count()).w()? },
+                unsafe { dev.alloc::<bf16>(out_shape.elem_count())? },
                 (n * m),
             )
         };
 
         let config = MatmulConfig {
             transa: true,
+            transc: false,
             transb: false,
             m: m as u64,
             n: n as u64,
@@ -710,13 +714,14 @@ impl CublasLTBatchMatmul {
         } else {
             // Allocate out tensor
             (
-                unsafe { dev.alloc::<f32>(out_shape.elem_count()).w()? },
+                unsafe { dev.alloc::<f32>(out_shape.elem_count())? },
                 (n * m),
             )
         };
 
         let config = MatmulConfig {
             transa: true,
+            transc: false,
             transb: false,
             m: m as u64,
             n: n as u64,


### PR DESCRIPTION
Updates the crate to build against the current spiceai candle fork (`spiceai/candle` at rev `fab4da81`, candle-core `0.10.1`) and the matching `cudarc` `0.19` API.

## What changed

### `Cargo.toml`

- Pin candle to `=0.10.1`. Previously it was declared as `candle = { version = "*", package = "candle-core" }`, which silently resolved to `candle-core 0.8.4` from crates.io whenever a downstream workspace had any other candle-core in the graph. The two candle-core instances produced distinct `CudaSlice` / `CudaView` types, which broke the `DevicePtr<T>` trait bounds that `cudarc::cublaslt::Matmul::matmul` relies on.
- Bump `cudarc` to `0.19` with explicit features: `std`, `cublas`, `cublaslt`, `curand`, `driver`, `nvrtc`, `f16`, `f8`, `cuda-version-from-build-system`, `dynamic-linking`. This keeps the linking mode unambiguous for downstream consumers (cudarc's `build.rs` panics if none of static/dynamic-loading/dynamic-linking is active).
- Drop the `[patch.crates-io]` override for `cudarc` — all feature configuration now lives on the direct dependency.

### `src/lib.rs` (cudarc 0.19 API)

- `MatmulConfig` gained a required `transc: bool` field in 0.19; populate it as `false` at every builder site.
- `CudaBlasLT::new` now takes `Arc<CudaStream>` instead of `Arc<CudaDevice>`; switch to `dev.cuda_stream()`.
- In candle 0.10, `CudaDevice::alloc::<T>` already returns `candle_core::Result`, so the `.w()?` wrappers are redundant.
- Drop the now-unused `use candle::cuda_backend::WrapErr;` import.

## Validation

- Consumer workspace (`spiceai/spiceai`, branch `lukim/lockstep-candle-0.10.1-mistral-0.8.0`) builds cleanly: `cargo build --release --features cuda` on CUDA 12.6 with `CUDA_COMPUTE_CAP=90`. Produces a working `spiced` binary (`v2.0.0-unstable-build.*+models.cuda`).

## Risk

Bumps the candle-core compatibility floor from "anything" to `=0.10.1` and the cudarc minimum from `0.17.6` to `0.19`. Both are required for the rest of the spiceai/candle upgrade lock-step; there are no known consumers still on the old pins.
