### PR TITLE
deps: bump candle requirement to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,11 @@ edition = "2021"
 description = "CUBLASLt gemm for the candle ML framework."
 
 [dependencies]
-# Depend on candle-core by its canonical name (renamed to `candle` in code)
-# so the workspace's [patch.crates-io] override for `candle-core` applies.
-# Previously this dep was declared as `candle = { version = "*", package = "candle-core" }`
-# which silently resolved to a different `candle-core` version than the rest of
-# the dep graph (0.8.4 vs 0.10.1), causing `CudaSlice` / `CudaView` to be
-# distinct types between this crate and candle, which broke the `DevicePtr`
+# Pin candle-core to an exact major so this crate resolves to the same
+# `candle-core` as the rest of the dependency graph, and depend on it by its
+# canonical name so a workspace `[patch.crates-io]` override applies. A loose
+# requirement can resolve to a second `candle-core`, which makes `CudaSlice` /
+# `CudaView` distinct types across the two copies and breaks the `DevicePtr`
 # trait bounds in `cudarc::cublaslt::Matmul::matmul`.
 candle = { version = "0.11", package = "candle-core", features = ["cuda"] }
 cudarc = { version = "0.19", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "CUBLASLt gemm for the candle ML framework."
 # the dep graph (0.8.4 vs 0.10.1), causing `CudaSlice` / `CudaView` to be
 # distinct types between this crate and candle, which broke the `DevicePtr`
 # trait bounds in `cudarc::cublaslt::Matmul::matmul`.
-candle = { version = "=0.10.1", package = "candle-core", features = ["cuda"] }
+candle = { version = "0.11", package = "candle-core", features = ["cuda"] }
 cudarc = { version = "0.19", default-features = false, features = [
     "std",
     "cublas",


### PR DESCRIPTION
## Summary
Accept **candle 0.11** (was pinned `=0.10.1`) so this crate resolves against the spiceai candle 0.11 fork used by the workspace (candle 0.11 + mistral.rs v0.9.0 upgrade).

cudarc stays on the 0.19 minor (0.19.4 → 0.19.8), so the CUDA FFI (`DevicePtr` / `DeviceRepr` / `CustomOp`) is unchanged and no code port is needed. Consumed transitively via the tei fork and the spiceai workspace candle patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
